### PR TITLE
Update README to current situation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,10 @@
 
 # Workflomics version 2.0
 
-## Requirements
+This repository contains the CWL files and other files used the generate Workflomics workflows.
+They are normally executed using the [Workflomics Benchmarker](https://github.com/Workflomics/workflomics-benchmarker) 
+or using the [cwltool](https://github.com/common-workflow-language/cwltool) (or other CWL runner).
 
-- cwltool (Tested with cwltool 3.1.20230719185429)
-- python (Tested with Python 3.9.12)
-- docker (Tested with Docker version 24.0.6, build ed223bc)
-- singularity/apptainer (optional) (Tested with singularity version 1.1.6)
+When using Workflomics web interface, the files are obtained from this repository directly, so you don't need to clone this repository for normal usage in the Workflomics environment.
 
-## Running and benchmarking CWL workflows
-
-Clone the repository and checkout the continerless branch:
-
-```
-git clone https://github.com/Workflomics/containers.git
-cd containers
-git checkout continerless
-```
-
-Create `data` directory and a `outputs` subdirectory. Enable file sharing for the `data` and `cwl` directory. With Docker Desktop dashboard this could be achived with Settings -> Resources -> File sharing. For running example2 workflow (Comet -> PeptideProphet -> ProteinProphet -> StPeter), run the following command in the root directory of the project. The command is tested on Ubuntu. Update the paths according to your OS:
- 
-```
-python workflomics_runner/workflomics.py run --outdir ./data/outputs --workflow ./cwl/workflows/example2/workflow_2.cwl --input ./cwl/workflows/example2/input.yml
-```
-
-The command will ask you to enter the paths to the input files. The output files will be saved in `./data/outputs`. The --workflow flag specifies the path to a directory containing workflows or a list of space-separated path to workflow files.
-
-To benchmark the workflow, run the following command in the root directory of the project. The command is tested on Ubuntu. Update the paths according to your OS:
-
-```
-python ./workflomics_runner/workflomics.py benchmark --outdir ./data/outputs --workflow ./cwl/workflows/example2/workflow_2.cwl --input ./cwl/workflows/example2/input.yml
-```
-
-Bechmarking results will be saved in `./data/outputs/benchmarking_results.json`. 
-
-Using the `--singularity` flag will run the workflow using singularity instead of docker.
+To add new tools to the Workflomics environment, CWL files and other files needed to run these tools should be added to this repository.


### PR DESCRIPTION
In the current Workflomics setup, the generated workflows contains all the CWL and related files directly. The previous setup for running the CWL directly is no longer used. To avoid confusion, the description is mostly deleted.

Fixes #59